### PR TITLE
zIndex is now a parameter

### DIFF
--- a/addon/components/ember-spinner.js
+++ b/addon/components/ember-spinner.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend({
   width: 22,
   speed: 1.7,
   rotate: 55,
+  zIndex: 2000000000,
   configArgs: {},
 
   lookupUpConfig: function() {
@@ -28,6 +29,7 @@ export default Ember.Component.extend({
       top:      this.get('top'),
       left:     this.get('left'),
       color:    this.get('color'),
+      zIndex:    this.get('zIndex'),
       hwaccel:  true
     };
 


### PR DESCRIPTION
Hey, sorry about the wait. I added zIndex as a configurable parameter just like the actual spin.js library. Does this work? Any suggestions?