### PR TITLE
These fixes allow ember-cli-spinjs to be used as a Nested addon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ module.exports = {
   name: 'ember-cli-spinjs',
 
   included: function(app) {
+     // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
     this._super.included(app);
 
     app.import(app.bowerDirectory + '/spin.js/spin.js');


### PR DESCRIPTION
check out https://github.com/ember-cli/ember-cli/issues/3718 for a detailed error description for what happens currently without this patch.