### PR TITLE
Suppress rollup warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,16 @@ module.exports = {
         output: {
           file: 'spin.js',
           format: 'es'
-        }
+        },
+        onwarn: function(warning) {
+          // Suppress known error message caused by TypeScript compiled code with Rollup
+          // https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined
+          if (warning.code === 'THIS_IS_UNDEFINED') {
+            return;
+          }
+          // eslint-disable-next-line no-console
+          console.log("Rollup warning: ", warning.message);
+        },
       }
     });
 


### PR DESCRIPTION
Prevent warnings from rollup: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`